### PR TITLE
Switch to using deployer library

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "marked": "^0.8.2",
     "marked-terminal": "^4.0.0",
     "mkdirp": "^1.0.4",
-    "nimbella-cli": "https://preview-apigcp.nimbella.io/nimbella-cli.tgz",
+    "nimbella-deployer": "https://preview-apigcp.nimbella.io/nimbella-deployer.tgz",
     "open": "^7.0.3",
     "shelljs": "^0.8.3",
     "terminal-link": "^2.1.1",

--- a/src/commander/commander.js
+++ b/src/commander/commander.js
@@ -17,8 +17,7 @@ const chalk = require('chalk');
 const open = require('open');
 const inquirer = require('inquirer');
 const inquirerCommandPrompt = require('inquirer-command-prompt');
-const { NimBaseCommand } = require('nimbella-cli/lib/NimBaseCommand');
-const { nimbellaDir } = require('nimbella-cli/lib/deployer/credentials');
+const { NimBaseCommand, nimbellaDir } = require('nimbella-deployer');
 
 const login = require('../login');
 const renderResult = require('../render');

--- a/src/commands/history/index.js
+++ b/src/commands/history/index.js
@@ -1,5 +1,5 @@
 const { join } = require('path');
-const { nimbellaDir } = require('nimbella-cli/lib/deployer/credentials');
+const { nimbellaDir } = require('nimbella-deployer');
 
 module.exports = async () => {
   const historyFile = join(

--- a/src/login.js
+++ b/src/login.js
@@ -16,7 +16,7 @@ const {
   addCommanderData,
   getCredentials,
   fileSystemPersister,
-} = require('nimbella-cli/lib/deployer');
+} = require('nimbella-deployer');
 
 const workbenchURL = 'https://apigcp.nimbella.io/wb';
 


### PR DESCRIPTION
Breaks circular dependency.  Issue nimbella-corp/nimbella-cli#282

This _seems_ to work.   However, there have been build problems observed in the past by others and not by me.

I recommend trying it out and testing the result as thoroughly as you can before merging.